### PR TITLE
Align donation messaging with RScreenFlash style

### DIFF
--- a/DpiHelper.cs
+++ b/DpiHelper.cs
@@ -25,7 +25,7 @@ namespace RScreenRec
             }
             catch
             {
-                // Fallback usando Graphics
+                // Fallback using Graphics
                 using (Graphics g = Graphics.FromHwnd(IntPtr.Zero))
                 {
                     return g.DpiX / DEFAULT_DPI;
@@ -37,7 +37,7 @@ namespace RScreenRec
         {
             try
             {
-                // Per Windows 10+, ogni monitor può avere DPI diverso
+                // Windows 10+ can report different DPI values per monitor
                 using (Graphics g = Graphics.FromHwnd(IntPtr.Zero))
                 {
                     return g.DpiX / DEFAULT_DPI;

--- a/Program.cs
+++ b/Program.cs
@@ -30,15 +30,15 @@ namespace RScreenRec
         [STAThread]
         static void Main()
         {
-            // ✅ Configura DPI awareness moderno per multi-monitor
+            // ✅ Configure modern DPI awareness for multi-monitor setups
             try
             {
-                // Prova prima il metodo moderno (Windows 8.1+)
+                // Try the modern method first (Windows 8.1+)
                 SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
             }
             catch
             {
-                // Fallback al metodo legacy (Windows Vista+)
+                // Fall back to the legacy method (Windows Vista+)
                 SetProcessDPIAware();
             }
 
@@ -65,7 +65,7 @@ namespace RScreenRec
                 return;
             }
 
-            // ✅ Ottiene il monitor corretto sotto al cursore
+            // ✅ Get the monitor under the cursor
             Screen activeScreen = Screen.FromPoint(Cursor.Position);
             Rectangle bounds = activeScreen.Bounds;
 
@@ -107,19 +107,19 @@ namespace RScreenRec
                 return;
             }
 
-            // Overlay pallino
+            // Recording indicator overlay
             var overlay = new RecordingOverlayForm(bounds);
             Thread overlayThread = new Thread(() => Application.Run(overlay));
             overlayThread.SetApartmentState(ApartmentState.STA);
             overlayThread.Start();
 
-            // Overlay touch
+            // Touch indicator overlay
             var touchOverlay = new TouchOverlayForm(bounds);
             Thread touchThread = new Thread(() => Application.Run(touchOverlay));
             touchThread.SetApartmentState(ApartmentState.STA);
             touchThread.Start();
 
-            // Attendi la rimozione del file di lock
+            // Wait for the lock file to be removed
             while (File.Exists(LockFilePath))
             {
                 Thread.Sleep(300);

--- a/README.md
+++ b/README.md
@@ -155,3 +155,7 @@ Contributions are welcome! To contribute:
 2. Create a feature branch (`git checkout -b feature/new-feature`).
 3. Commit your changes with clear messages.
 4. Open a pull request describing your changes.
+
+## Support
+
+If RScreenRec helps you work faster, you can buy me a coffee by sending a PayPal donation through the [direct contribution page](https://www.paypal.com/donate?business=paolo.ruba.1913%40gmail.com&no_recurring=0&item_name=Support+RScreenRec&currency_code=EUR).

--- a/RecordingOverlayForm.cs
+++ b/RecordingOverlayForm.cs
@@ -15,7 +15,7 @@ namespace RScreenRec
             FormBorderStyle = FormBorderStyle.None;
             StartPosition = FormStartPosition.Manual;
 
-            // DPI-aware positioning e sizing
+            // DPI-aware positioning and sizing
             float dpiScale = DpiHelper.GetSystemDpiScale();
             int scaledOffsetY = DpiHelper.ScaleValue(70, dpiScale);
             int scaledOffsetX = DpiHelper.ScaleValue(30, dpiScale);
@@ -60,14 +60,14 @@ namespace RScreenRec
                 int scaledBorder1 = DpiHelper.ScaleValue(2, dpiScale);
                 int scaledBorder2 = DpiHelper.ScaleValue(4, dpiScale);
 
-                // Esterno nero
+                // Outer black ring
                 var blackRect = new Rectangle(0, 0, scaledSize, scaledSize);
                 using (SolidBrush blackBrush = new SolidBrush(Color.Black))
                 {
                     e.Graphics.FillEllipse(blackBrush, blackRect);
                 }
 
-                // Intermedio bianco
+                // Middle white ring
                 var whiteRect = new Rectangle(
                     scaledBorder1, scaledBorder1,
                     scaledSize - scaledBorder1 * 2, scaledSize - scaledBorder1 * 2
@@ -77,7 +77,7 @@ namespace RScreenRec
                     e.Graphics.FillEllipse(whiteBrush, whiteRect);
                 }
 
-                // Interno rosso
+                // Inner red circle
                 var centerRect = new Rectangle(
                     scaledBorder2, scaledBorder2,
                     scaledSize - scaledBorder2 * 2, scaledSize - scaledBorder2 * 2
@@ -90,7 +90,7 @@ namespace RScreenRec
         }
 
 
-        // Forziamo la finestra sempre on top
+        // Keep the window always on top
         [DllImport("user32.dll")]
         private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter,
             int X, int Y, int cx, int cy, uint uFlags);

--- a/TouchOverlayForm.cs
+++ b/TouchOverlayForm.cs
@@ -56,7 +56,7 @@ namespace RScreenRec
                 BringToFront();
             };
 
-            // Timer: ogni 500ms pulisce e ridisegna
+            // Timer: clear and repaint every 500 ms
             cleanupTimer = new Timer { Interval = 500 };
             cleanupTimer.Tick += (s, e) =>
             {


### PR DESCRIPTION
## Summary
- update the README support section to reuse the RScreenFlash donation wording while pointing to the same personal PayPal link

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ecdacbf7b483228512421ffc6764f8